### PR TITLE
Fixed highlight breaking after single perl line

### DIFF
--- a/grammars/html (mason).cson
+++ b/grammars/html (mason).cson
@@ -62,7 +62,7 @@
     'beginCaptures':
       '1':
         'name': 'punctuation.section.embedded.perl.mason'
-    'end': '$\\n?'
+    'end': '(?!\\G)'
     'name': 'source.perl.mason.line'
     'patterns': [
       {


### PR DESCRIPTION
Before:
![before_fix](https://cloud.githubusercontent.com/assets/1900106/6940347/4caa7018-d876-11e4-9bd5-b5c88f9440ba.png)

Now:
![fix_after](https://cloud.githubusercontent.com/assets/1900106/6940352/526de278-d876-11e4-9240-d76b845075a6.png)
