### PR TITLE
Don't break mason highlighting after method block

### DIFF
--- a/grammars/html (mason).cson
+++ b/grammars/html (mason).cson
@@ -15,7 +15,7 @@
         'name': 'punctuation.section.embedded.perl.mason'
       '2':
         'name': 'keyword.control'
-    'end': '(</%(\\2)>)(\\s*$\\n)?'
+    'end': '(<\\/%(\\2)>)[^\\n]*\\n?'
     'name': 'source.perl.mason.block'
     'patterns': [
       {
@@ -142,7 +142,7 @@
         'name': 'keyword.control'
       '2':
         'name': 'variable.other'
-    'end': '(</%(\\2)>)'
+    'end': '(</%(\\2)>)[^\\n]*\\n?'
     'name': 'source.mason.methods'
     'patterns': [
       {


### PR DESCRIPTION
Everything after a closed method block won't be highlighted

Old:
![screenshot from 2015-05-11 18 40 14](https://cloud.githubusercontent.com/assets/1900106/7570029/331389d0-f80d-11e4-97dd-bf1a6f82590d.png)

New:
![screenshot from 2015-05-11 18 39 19](https://cloud.githubusercontent.com/assets/1900106/7570037/3baf1050-f80d-11e4-8228-2ee98b545955.png)

``` mason
<%perl>
% ##############################################################################
</%perl>
% ##############################################################################

<%method asd>
% ##############################################################################
</%method>
% ##############################################################################
```
