### PR TITLE
Fix highlighting in filter tag

### DIFF
--- a/grammars/html (mason).cson
+++ b/grammars/html (mason).cson
@@ -9,7 +9,7 @@
 'name': 'HTML (Mason)'
 'patterns': [
   {
-    'begin': '(<%(perl|attr|global|once|init|cleanup|requestlocal|requestonce|shared|threadlocal|threadonce|flags)( scope.*?)?>)'
+    'begin': '(<%(perl|attr|global|once|init|cleanup|requestlocal|requestonce|shared|threadlocal|threadonce|flags|filter)( scope.*?)?>)'
     'captures':
       '1':
         'name': 'punctuation.section.embedded.perl.mason'


### PR DESCRIPTION
Syntax highlighting was not working inside a <%filter> section. This PR just adds it to the list of tags.
