### PR TITLE
add support for mi files

### DIFF
--- a/grammars/html (mason).cson
+++ b/grammars/html (mason).cson
@@ -5,6 +5,7 @@
   'md'
   'mc'
   'mas'
+  'mi'
 ]
 'name': 'HTML (Mason)'
 'patterns': [


### PR DESCRIPTION
Hi,

Realized its a single line change to add support for `.mi` files. You can find more details here https://metacpan.org/pod/Mason%3a%3aManual%3a%3aComponents#Component-file-extensions